### PR TITLE
moving changes on cnx-archive to cnxmltransforms

### DIFF
--- a/cnxmltransforms/resolvers.py
+++ b/cnxmltransforms/resolvers.py
@@ -413,13 +413,15 @@ class CnxmlToHtmlReferenceResolver(BaseReferenceResolver):
         the page is within the book.
         """
         plan = self.plpy.prepare(
-            'SELECT tree_to_json($1, $2, FALSE)::json', ('uuid', 'text'))
+            'SELECT tree_to_json($1, $2, FALSE)::json', ('text', 'text'))
         tree = self.plpy.execute(
             plan, (book_uuid, book_version))[0]['tree_to_json']
+        if isinstance(tree, basestring):
+            tree = json.loads(tree)
         pages = list(flatten_tree_to_ident_hashes(tree))
         book_ident_hash = join_ident_hash(book_uuid, book_version)
         page_ident_hash = join_ident_hash(page_uuid, page_version)
-        for p_ident_hash in flatten_tree_to_ident_hashes(tree):
+        for p_ident_hash in pages:
             p_id, p_version = split_ident_hash(p_ident_hash)
             if (p_id == page_uuid and
                     (page_version is None or

--- a/cnxmltransforms/tests/test_resolvers.py
+++ b/cnxmltransforms/tests/test_resolvers.py
@@ -364,6 +364,29 @@ class HtmlReferenceResolutionTestCase(unittest.TestCase):
             'http://legacy.cnx.org/content/m48897/latest?collection=col11441/'
             'latest'), (None, ()))
 
+    @testing.db_connect
+    def test_get_page_ident_hash(self, cursor):
+        book_uuid = 'e79ffde3-7fb4-4af3-9ec8-df648b391597'
+        book_version = '7.1'
+        page_uuid = '209deb1f-1a46-4369-9e0d-18674cf58a3e'
+        page_version = '7'
+
+        cursor.execute('''\
+CREATE FUNCTION test_get_page_ident_hash() RETURNS TEXT AS $$
+import io
+import plpy
+from cnxmltransforms.resolvers import CnxmlToHtmlReferenceResolver
+resolver = CnxmlToHtmlReferenceResolver(io.BytesIO('<html></html>'), plpy, 3)
+result = resolver.get_page_ident_hash(%s, %s, %s, %s)
+return result[1]
+$$ LANGUAGE plpythonu;
+SELECT test_get_page_ident_hash();''',
+                       (page_uuid, page_version, book_uuid, book_version))
+        self.assertEqual(
+            cursor.fetchone()[0],
+            '{}@{}:{}@{}'.format(
+                book_uuid, book_version, page_uuid, page_version))
+
 
 class CnxmlReferenceResolutionTestCase(unittest.TestCase):
     fixture = testing.data_fixture


### PR DESCRIPTION
taking the changes karen made on the transforms in cnx-archive (https://github.com/Connexions/cnx-archive/pull/504) and moving them to the transforms here in cnx-cnxml-transforms.

There are a couple little changes that were made to match changes made to cnx-archive's version of these tests to make things pass. (installing cnx-db in the travis file, changing line 216 in test_resolvers because that's how it was in cnx-archive, and skipping one test in test_converters because it was failing with `XMLSyntaxError: Entity 'lambda' not defined` and in cnx-archive it was skipped which made to code coverage go down though)

connected to https://github.com/Connexions/cnx-db/pull/38 and https://github.com/Connexions/cnx-archive/pull/504